### PR TITLE
Migarate to AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         minSdkVersion 15
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
     }
 }
@@ -32,7 +32,7 @@ android {
 dependencies {
     api 'com.squareup.okhttp3:okhttp:4.1.1'
 
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.annotation:annotation:1.0.0'
     implementation ('org.simpleframework:simple-xml:2.7.1') {
         exclude module: 'stax'
         exclude module: 'stax-api'

--- a/src/main/java/com/thegrizzlylabs/sardineandroid/impl/BasicAuthenticator.java
+++ b/src/main/java/com/thegrizzlylabs/sardineandroid/impl/BasicAuthenticator.java
@@ -1,6 +1,6 @@
 package com.thegrizzlylabs.sardineandroid.impl;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.IOException;
 

--- a/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
+++ b/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
@@ -1,6 +1,6 @@
 package com.thegrizzlylabs.sardineandroid.impl;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.thegrizzlylabs.sardineandroid.DavAce;
 import com.thegrizzlylabs.sardineandroid.DavAcl;


### PR DESCRIPTION
I am using sardine-android as submodule. I am facing "error: package android.support.annotation does not exist" with "android.support", so I migrate project to AndroidX.