### PR TITLE
Support Android below 19

### DIFF
--- a/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
+++ b/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
@@ -105,7 +105,7 @@ public class OkHttpSardine implements Sardine {
 
         @Override
         public Response intercept(Chain chain) throws IOException {
-            Request request = chain.request().newBuilder().addHeader("Authorization", Credentials.basic(userName, password)).build();
+            Request request = chain.request().newBuilder().addHeader("Authorization", Credentials.basic(userName, password, SardineUtil.standardUTF8())).build();
             return chain.proceed(request);
         }
     }

--- a/src/main/java/com/thegrizzlylabs/sardineandroid/util/SardineUtil.java
+++ b/src/main/java/com/thegrizzlylabs/sardineandroid/util/SardineUtil.java
@@ -237,4 +237,20 @@ public final class SardineUtil {
     public static Element createElement(Element parent, QName key) {
         return parent.getOwnerDocument().createElementNS(key.getNamespaceURI(), key.getPrefix() + ":" + key.getLocalPart());
     }
+   
+    /**
+     *  @return standard UTF8 charset on any version of Android
+     */
+    public static Charset standardUTF8()
+    {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT)
+        {
+            return StandardCharsets.UTF_8;
+        }
+        else
+        {
+            //noinspection CharsetObjectCanBeUsed
+            return Charset.forName("UTF-8");
+        }
+    }
 }


### PR DESCRIPTION
Google still "actively" supports Android 14 and above, so IMO it's important that useful libraries like this one supports it too. And considering how little there is to change it'll be a shame not to have it.

So far, tested list(), get(), put() (with a custom inputstream), get() with specific properties (size, type and modified) and move(). All working good so far on Android 4.2.2.

PS: My first PR, so I'm not sure I'm doing it right.