### PR TITLE
Fix HTTP 207 didn't handled properly

### DIFF
--- a/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
+++ b/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
@@ -404,8 +404,7 @@ public class OkHttpSardine implements Sardine {
     public boolean exists(String url) throws IOException {
         Request request = new Request.Builder()
                 .url(url)
-                .header("Depth", "0")
-                .method("PROPFIND", null)
+                .method("HEAD", null)
                 .build();
 
         return execute(request, new ExistsResponseHandler());


### PR DESCRIPTION
My environment: `nginx/1.18.0 (Ubuntu)`, `sardine-android:0.8`
On Nginx WebDAV server, if you send a `PROPFIND` request, it will return a HTTP 207 response listing all possible files. But in my case, `sardine.exists` checks only the HTTP status code <= 299 instead of parsing into the XML file.
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/17663689/112817726-571e0e80-90b5-11eb-9fea-6b48d2bc8071.png">
Since I don't want to implement a XML parser, I change this request to `HEAD` as [the OG sardine did](https://github.com/lookfirst/sardine/blob/df3d477ecb57529a0741647e8132ab6fcb2f7700/src/main/java/com/github/sardine/impl/SardineImpl.java#L1004). 