### PR TITLE
Fix an error when move to a path containing spaces

### DIFF
--- a/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
+++ b/src/main/java/com/thegrizzlylabs/sardineandroid/impl/OkHttpSardine.java
@@ -369,7 +369,7 @@ public class OkHttpSardine implements Sardine {
                 .method("MOVE", null);
 
         Headers.Builder headersBuilder = new Headers.Builder();
-        headersBuilder.add("DESTINATION", URI.create(destinationUrl).toASCIIString());
+        headersBuilder.add("DESTINATION", destinationUrl);
         headersBuilder.add("OVERWRITE", overwrite ? "T" : "F");
 
         if (lockToken != null) {

--- a/src/test/java/com/thegrizzlylabs/sardineandroid/FunctionalSardineTest.java
+++ b/src/test/java/com/thegrizzlylabs/sardineandroid/FunctionalSardineTest.java
@@ -210,6 +210,18 @@ public class FunctionalSardineTest {
     }
 
     @Test
+    public void testMoveToFolderIncludeBlank() throws Exception {
+        final String source = WEBDAV_URL + "/" + testFolder + "/" + UUID.randomUUID().toString();
+        final String destination = WEBDAV_URL + "/" + testFolder + "/" + UUID.randomUUID().toString() + " blank test";
+        sardine.put(source, "Test".getBytes());
+
+        sardine.move(source, destination);
+
+        assertFalse(sardine.exists(source));
+        assertTrue(sardine.exists(destination));
+    }
+
+    @Test
     public void testMoveOverwriting() throws Exception {
         final String source = WEBDAV_URL + "/" + testFolder + "/" + UUID.randomUUID().toString();
         final String destination = WEBDAV_URL + "/" + testFolder + "/" + UUID.randomUUID().toString();


### PR DESCRIPTION
`URISyntaxException` occurred when move destination path has spaces.

I removed `URI.create(...)` about destination url.
Also added test case for this case.

```
Caused by: java.net.URISyntaxException: Illegal character in path at index 120: http://demo.owncloud.org/remote.php/webdav/test8cec534b-73b9-4f45-89a6-e9f278359690/60fbf14d-5689-421e-a316-54754de220d8 blank test
	at java.net.URI$Parser.fail(URI.java:2848)
	at java.net.URI$Parser.checkChars(URI.java:3021)
	at java.net.URI$Parser.parseHierarchical(URI.java:3105)
	at java.net.URI$Parser.parse(URI.java:3053)
	at java.net.URI.<init>(URI.java:588)
	at java.net.URI.create(URI.java:850)
	... 31 more
```

Thanks for reviewing.